### PR TITLE
Delete extra slashes in Dockerfile

### DIFF
--- a/docker/single/Dockerfile
+++ b/docker/single/Dockerfile
@@ -77,7 +77,7 @@ RUN export $(cat /tmp/geckodriver_version) && \
 # Generate App
 COPY ./source/ $APP_HOME/
 COPY .env $APP_HOME/
-RUN [ -f /$APP_HOME/.env ] || cp .env /$APP_HOME/
+RUN [ -f $APP_HOME/.env ] || cp .env $APP_HOME/
 
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
On build I see:

`=> [30/31] RUN [ -f //usr/src/app/.env ] || cp .env //usr/src/app/ 
`
Double slashes happens because `APP_HOME` starting with slash `/usr/src/app `

I suggest to remove extra / 